### PR TITLE
feat: habilitar botones de acceso rápido también en entorno Vercel

### DIFF
--- a/frontend/components/Auth/LoginForm.jsx
+++ b/frontend/components/Auth/LoginForm.jsx
@@ -29,6 +29,12 @@ const LoginForm = () => {
     await login('lpardo@trucco.es', 'password123');
   };
 
+  // Comprobar si estamos en un entorno de testing (desarrollo local o Vercel)
+  const isTestingEnvironment = () => {
+    return process.env.NODE_ENV === 'development' || 
+           (typeof window !== 'undefined' && window.location.hostname.includes('vercel.app'));
+  };
+
   return (
     <Card className="max-w-md w-full mx-auto">
       <h2 className="text-2xl font-bold text-gray-900 mb-6 text-center">Iniciar Sesión</h2>
@@ -92,8 +98,8 @@ const LoginForm = () => {
         Sólo usuarios autorizados. El acceso a esta plataforma está restringido.
       </p>
       
-      {/* Botones de acceso rápido para testing - Solo visible en desarrollo */}
-      {process.env.NODE_ENV === 'development' && (
+      {/* Botones de acceso rápido para testing - Visible en desarrollo y Vercel */}
+      {isTestingEnvironment() && (
         <div className="mt-4 p-4 bg-gray-50 border border-gray-200 rounded-md">
           <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-3">Acceso rápido para testing</h3>
           <div className="grid grid-cols-2 gap-3">
@@ -117,8 +123,8 @@ const LoginForm = () => {
         </div>
       )}
       
-      {/* Credenciales de demostración - Solo para desarrollo */}
-      {process.env.NODE_ENV === 'development' && (
+      {/* Credenciales de demostración - Visible en desarrollo y Vercel */}
+      {isTestingEnvironment() && (
         <div className="mt-4 p-3 bg-gray-50 border border-gray-200 rounded-md">
           <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">Credenciales de demostración</h3>
           <p className="text-xs text-gray-600 mb-1"><span className="font-semibold">Manager:</span> <span className="font-mono">manager@example.com</span> / <span className="font-mono">password123</span></p>


### PR DESCRIPTION
# Habilitar botones de acceso rápido en entorno Vercel

## Descripción
Esta PR añade la posibilidad de ver y usar los botones de acceso rápido en el entorno de Vercel para facilitar el testing sin necesidad de introducir credenciales manualmente.

## Cambios realizados
- Se ha creado una función `isTestingEnvironment()` que detecta si estamos en desarrollo local o en Vercel
- Se ha modificado la condición para mostrar los botones y credenciales de demostración usando esta nueva función
- Los botones siguen sin aparecer en entornos de producción no Vercel

## Beneficios
- Facilita el testing en el entorno de Vercel sin necesidad de recordar credenciales
- Mantiene la seguridad al seguir ocultando estos controles en el entorno de producción final